### PR TITLE
chore(strings): shorten crash notification text

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -927,7 +927,7 @@
     <!-- ID of the default folder created on first start (camera folder). Must only contain 'a-z0-9_-'. Parameter is the device name-->
     <string name="default_folder_id">%1$s-photos</string>
 
-    <string name="notification_crash_title">Syncthing has crashed (exit code %1$s)</string>
+    <string name="notification_crash_title">Crashed (exit code %1$s)</string>
     <string name="notification_crash_text">Click for logs (%1$s)</string>
 
     <string name="notifications_persistent_channel">Syncthing active</string>


### PR DESCRIPTION
This was one of the notification texts I glossed over in Catfriend1#1319, I noticed it recently (ref Catfriend1#1336).

# Description
Describe what this PR is about

# Changes
What changes are made in this PR
* change 1
* change 2

# Screenshots
In case of UI changes, add before and after screenshots

| Before | After |
| ------ | ----- |
| ![before][] | ![after][] |

[before]: before.png
[after]: after.png
